### PR TITLE
Create table include

### DIFF
--- a/_includes/table.html
+++ b/_includes/table.html
@@ -1,0 +1,30 @@
+<div class="expand">
+  <table>
+    <thead>
+      <tr>
+        <th>Test case</th>
+        {%-for heading in include.headings-%}
+        <th>{{heading.title}}<br />{{heading.version}}</th>
+        {%-endfor-%}
+      </tr>
+    </thead>
+    <tbody>
+      {%-for case in include.cases-%}
+      <tr>
+        <td>
+          {{case.title}}
+          <pre><code>{{case.example}}</code></pre>
+        </td>
+        {%-for heading in include.headings-%} {% assign file = case[heading.id]
+        %}
+        <td>
+          {% include audio.html case=case.title title=heading.title file=file %}
+        </td>
+        {%-endfor-%}
+      </tr>
+      {%-endfor-%}
+    </tbody>
+  </table>
+</div>
+
+<a class="button" href="test">View test case page</a>

--- a/_includes/table.html
+++ b/_includes/table.html
@@ -3,9 +3,10 @@
     <thead>
       <tr>
         <th>Test case</th>
-        {%-for heading in include.headings-%}
-        <th>{{heading.title}}<br />{{heading.version}}</th>
-        {%-endfor-%}
+        <th>VoiceOver<br />macOS 10.15</th>
+        <th>JAWS 2020<br />Windows 8.1</th>
+        <th>NVDA 2019.2.1<br />Windows 8.1</th>
+        <th>VoiceOver<br />iOS 13</th>
       </tr>
     </thead>
     <tbody>
@@ -15,16 +16,26 @@
           {{case.title}}
           <pre><code>{{case.example}}</code></pre>
         </td>
-        {%-for heading in include.headings-%} {% assign file = case[heading.id]
-        %}
         <td>
-          {% include audio.html case=case.title title=heading.title file=file %}
+          {% if case.macos %}{% include audio.html case=case.title title="macOS"
+          file=case.macos %}{% endif %}
         </td>
-        {%-endfor-%}
+        <td>
+          {% if case.jaws %}{% include audio.html case=case.title title="JAWS"
+          file=case.jaws %}{% endif %}
+        </td>
+        <td>
+          {% if case.nvda %}{% include audio.html case=case.title title="NVDA"
+          file=case.nvda %}{% endif %}
+        </td>
+        <td>
+          {% if case.ios %}{% include audio.html case=case.title title="iOS"
+          file=case.ios %}{% endif %}
+        </td>
       </tr>
       {%-endfor-%}
     </tbody>
   </table>
 </div>
 
-<a class="button" href="test">View test case page</a>
+<p><a class="button" href="test">View test case page</a></p>

--- a/_posts/2020-07-04-punctuation-in-alt-text.md
+++ b/_posts/2020-07-04-punctuation-in-alt-text.md
@@ -1,5 +1,18 @@
 ---
 title: Punctuation in alt text
+headings:
+  - title: VoiceOver
+    version: macOS 10.15
+    id: macos
+  - title: JAWS 2020
+    version: Windows 8.1
+    id: jaws
+  - title: NVDA 2019.2.1
+    version: Windows 8.1
+    id: nvda
+  - title: VoiceOver
+    version: iOS 13
+    id: ios
 cases:
   - title: No punctuation
     example: "A shape with eight sides"
@@ -32,35 +45,7 @@ cases:
 
 This test details audible effects of punctuation in alternative text when read by different screen readers.
 
-<div class="expand">
-<table>
-  <thead>
-    <tr>
-      <th>Test case</th>
-      <th>VoiceOver<br>macOS 10.15</th>
-      <th>JAWS 2020<br>Windows 8.1</th>
-      <th>NVDA 2019.2.1<br>Windows 8.1</th>
-      <th>VoiceOver<br>iOS 13</th>
-    </tr>
-  </thead>
-  <tbody>
-  {%-for case in page.cases-%}
-    <tr>
-      <td>
-        {{case.title}}
-        <pre><code>{{case.example}}</code></pre>
-      </td>
-      <td>{% include audio.html case=case.title title="macOS" file=case.macos %}</td>
-      <td>{% include audio.html case=case.title title="JAWS" file=case.jaws %}</td>
-      <td>{% include audio.html case=case.title title="NVDA" file=case.nvda %}</td>
-      <td>{% include audio.html case=case.title title="iOS" file=case.ios %}</td>
-    </tr>
-  {%-endfor-%}
-  </tbody>
-</table>
-</div>
-
-<a class="button" href="test">View test case page</a>
+{% include table.html headings=page.headings cases=page.cases %}
 
 ## Findings
 

--- a/_posts/2020-07-04-punctuation-in-alt-text.md
+++ b/_posts/2020-07-04-punctuation-in-alt-text.md
@@ -32,7 +32,7 @@ cases:
 
 This test details audible effects of punctuation in alternative text when read by different screen readers.
 
-{% include table.html headings=page.headings cases=page.cases %}
+{% include table.html cases=page.cases %}
 
 ## Findings
 

--- a/_posts/2020-07-04-punctuation-in-alt-text.md
+++ b/_posts/2020-07-04-punctuation-in-alt-text.md
@@ -1,18 +1,5 @@
 ---
 title: Punctuation in alt text
-headings:
-  - title: VoiceOver
-    version: macOS 10.15
-    id: macos
-  - title: JAWS 2020
-    version: Windows 8.1
-    id: jaws
-  - title: NVDA 2019.2.1
-    version: Windows 8.1
-    id: nvda
-  - title: VoiceOver
-    version: iOS 13
-    id: ios
 cases:
   - title: No punctuation
     example: "A shape with eight sides"

--- a/_posts/2020-07-05-bold-and-italics.md
+++ b/_posts/2020-07-05-bold-and-italics.md
@@ -34,7 +34,7 @@ cases:
 
 This test details the audible effects of bold and italic markup when read by different screen readers.
 
-{% include table.html headings=page.headings cases=page.cases %}
+{% include table.html cases=page.cases %}
 
 ## Findings
 

--- a/_posts/2020-07-05-bold-and-italics.md
+++ b/_posts/2020-07-05-bold-and-italics.md
@@ -1,5 +1,18 @@
 ---
 title: Bold and italics
+headings:
+  - title: VoiceOver
+    version: macOS 10.15
+    id: macos
+  - title: JAWS 2020
+    version: Windows 8.1
+    id: jaws
+  - title: NVDA 2019.2.1
+    version: Windows 8.1
+    id: nvda
+#  - title: VoiceOver
+#    version: iOS 13
+#    id: ios
 cases:
   - title: Unstyled
     example: "The quick brown fox jumps over the lazy dog."
@@ -34,33 +47,7 @@ cases:
 
 This test details the audible effects of bold and italic markup when read by different screen readers.
 
-<div class="expand">
-<table>
-  <thead>
-    <tr>
-      <th>Test case</th>
-      <th>VoiceOver<br>macOS 10.15</th>
-      <th>JAWS 2020<br>Windows 8.1</th>
-      <th>NVDA 2019.2.1<br>Windows 8.1</th>
-    </tr>
-  </thead>
-  <tbody>
-  {%-for case in page.cases-%}
-    <tr>
-      <td>
-        {{case.title}}
-        <pre><code>{{case.example}}</code></pre>
-      </td>
-      <td>{% include audio.html case=case.title title="macOS" file=case.macos %}</td>
-      <td>{% include audio.html case=case.title title="JAWS" file=case.jaws %}</td>
-      <td>{% include audio.html case=case.title title="NVDA" file=case.nvda %}</td>
-    </tr>
-  {%-endfor-%}
-  </tbody>
-</table>
-</div>
-
-<a class="button" href="test">View test case page</a>
+{% include table.html headings=page.headings cases=page.cases %}
 
 ## Findings
 

--- a/_posts/2020-07-05-bold-and-italics.md
+++ b/_posts/2020-07-05-bold-and-italics.md
@@ -1,18 +1,5 @@
 ---
 title: Bold and italics
-headings:
-  - title: VoiceOver
-    version: macOS 10.15
-    id: macos
-  - title: JAWS 2020
-    version: Windows 8.1
-    id: jaws
-  - title: NVDA 2019.2.1
-    version: Windows 8.1
-    id: nvda
-#  - title: VoiceOver
-#    version: iOS 13
-#    id: ios
 cases:
   - title: Unstyled
     example: "The quick brown fox jumps over the lazy dog."


### PR DESCRIPTION
This PR merges into #9 to create a table include. 

~~With this change, we'll also need to define `headings` in the frontmatter to build the heading for each table. The `id` in the mapping corresponds to each test cases audio file.~~ 