### PR TITLE
Add related resources

### DIFF
--- a/related-resources.md
+++ b/related-resources.md
@@ -2,20 +2,24 @@
 title: Related resources
 ---
 
-- [Introduction to Screen Readers Using VoiceOver](https://www.youtube.com/watch?v=Y2vjyDxkIPs) — Ethan Marcotte on using VoiceOver to read and navigate web pages
+- [Introduction to screen readers using VoiceOver](https://www.youtube.com/watch?v=Y2vjyDxkIPs) — Ethan Marcotte on using VoiceOver to read and navigate web pages
 
-- [Getting Started with VoiceOver and Accessibility](https://bocoup.com/blog/getting-started-with-voiceover-accessibility) — Introduction to VoiceOver, settings recommendations 🙂, and recommendations for testing in other screen readers
+- [Getting started with VoiceOver and accessibility](https://bocoup.com/blog/getting-started-with-voiceover-accessibility) — Introduction to VoiceOver, settings recommendations 🙂, and recommendations for testing in other screen readers
 
-- [WebAIM Screen Reader User Survey #8 Results](https://webaim.org/projects/screenreadersurvey8/) — In August - September 2019, WebAIM surveyed preferences of screen reader users (1224 responses)
+- [WebAIM screen reader user survey #8 results](https://webaim.org/projects/screenreadersurvey8/) — In August - September 2019, WebAIM surveyed preferences of screen reader users (1224 responses)
 
-- [PowerMapper Assistive technology compatibility tests](https://www.powermapper.com/tests/) — An extensive library of screen reader tests
+- [PowerMapper assistive technology compatibility tests](https://www.powermapper.com/tests/) — An extensive library of screen reader tests
+
+- [Aural UI of HTML elements](https://thepaciellogroup.github.io/AT-browser-tests/) — Isolated tests and baseline support findings for all HTML elements
 
 - [3needs screenreader test pages](http://www.3needs.org/en/testing/sr-html.html) — Screen reader test pages of standard HTML markup, including data tables
 
-- [VoiceOver User Guide for macOS Catalina (10.15)](https://help.apple.com/voiceover/mac/10.15/)
+- [VoiceOver user guide for macOS Catalina (10.15)](https://help.apple.com/voiceover/mac/10.15/)
 
-- [Learn VoiceOver Gestures on iOS](https://support.apple.com/guide/iphone/learn-voiceover-gestures-iph3e2e2281/ios)
+- [Learn VoiceOver gestures on iOS](https://support.apple.com/guide/iphone/learn-voiceover-gestures-iph3e2e2281/ios)
 
 - [NVDA from NV Access](https://www.nvaccess.org/download/)
 
 - [JAWS from Freedom Scientific](https://www.freedomscientific.com/products/software/jaws/)
+
+- [Screen reader keyboard shortcuts and gestures](https://dequeuniversity.com/screenreaders/) — quick reference for navigating with JAWS, Narrator, NVDA, Talkback, and VoiceOver

--- a/related-resources.md
+++ b/related-resources.md
@@ -2,24 +2,30 @@
 title: Related resources
 ---
 
+## Screen readers
+
+- [NVDA from NV Access](https://www.nvaccess.org/download/)
+
+- [JAWS from Freedom Scientific](https://www.freedomscientific.com/products/software/jaws/)
+
+- [VoiceOver user guide for macOS Catalina (10.15)](https://help.apple.com/voiceover/mac/10.15/)
+
+- [WebAIM screen reader user survey #8 results](https://webaim.org/projects/screenreadersurvey8/) — In August - September 2019, WebAIM surveyed preferences of screen reader users (1224 responses)
+
+## How-to
+
 - [Introduction to screen readers using VoiceOver](https://www.youtube.com/watch?v=Y2vjyDxkIPs) — Ethan Marcotte on using VoiceOver to read and navigate web pages
 
 - [Getting started with VoiceOver and accessibility](https://bocoup.com/blog/getting-started-with-voiceover-accessibility) — Introduction to VoiceOver, settings recommendations 🙂, and recommendations for testing in other screen readers
 
-- [WebAIM screen reader user survey #8 results](https://webaim.org/projects/screenreadersurvey8/) — In August - September 2019, WebAIM surveyed preferences of screen reader users (1224 responses)
+- [Screen reader keyboard shortcuts and gestures](https://dequeuniversity.com/screenreaders/) — quick reference for navigating with JAWS, Narrator, NVDA, Talkback, and VoiceOver
+
+- [Learn VoiceOver gestures on iOS](https://support.apple.com/guide/iphone/learn-voiceover-gestures-iph3e2e2281/ios)
+
+## Test cases
 
 - [PowerMapper assistive technology compatibility tests](https://www.powermapper.com/tests/) — An extensive library of screen reader tests
 
 - [Aural UI of HTML elements](https://thepaciellogroup.github.io/AT-browser-tests/) — Isolated tests and baseline support findings for all HTML elements
 
 - [3needs screenreader test pages](http://www.3needs.org/en/testing/sr-html.html) — Screen reader test pages of standard HTML markup, including data tables
-
-- [VoiceOver user guide for macOS Catalina (10.15)](https://help.apple.com/voiceover/mac/10.15/)
-
-- [Learn VoiceOver gestures on iOS](https://support.apple.com/guide/iphone/learn-voiceover-gestures-iph3e2e2281/ios)
-
-- [NVDA from NV Access](https://www.nvaccess.org/download/)
-
-- [JAWS from Freedom Scientific](https://www.freedomscientific.com/products/software/jaws/)
-
-- [Screen reader keyboard shortcuts and gestures](https://dequeuniversity.com/screenreaders/) — quick reference for navigating with JAWS, Narrator, NVDA, Talkback, and VoiceOver


### PR DESCRIPTION
Changes links to sentence case and adds 2 new links:
- <https://thepaciellogroup.github.io/AT-browser-tests/>
- <https://dequeuniversity.com/screenreaders/>

@katydecorah any thoughts on organizing this list? Maybe headings — screen readers, test cases, tutorials?  
