### PR TITLE
Update browserslist config

### DIFF
--- a/.browserlistrc
+++ b/.browserlistrc
@@ -1,3 +1,0 @@
-# Browsers that we support
-
-> .5% in US and last 2 version

--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,0 +1,4 @@
+# Browsers that we support
+# run `npx browserslist` in this directory to see list
+
+defaults and > .5% in US, IE 11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12.x
-      - run: npm install
+      - run: npm ci
       - run: npm test
         env:
           CI: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 12.x
-      - run: npm ci
+      - run: npm install
       - run: npm test
         env:
           CI: true

--- a/.stylelintrc
+++ b/.stylelintrc
@@ -126,7 +126,7 @@
     "string-quotes": "double",
     "unit-no-unknown": true,
     "unit-case": "lower",
-    "unit-whitelist": ["em", "rem", "%", "s", "ch", "vh", "vw", "deg", "fr"],
+    "unit-allowed-list": ["em", "rem", "%", "s", "ch", "vh", "vw", "deg", "fr"],
     "value-list-comma-newline-after": null,
     "value-list-comma-space-after": "always-single-line",
     "value-list-comma-space-before": "never",
@@ -146,7 +146,6 @@
 
     "plugin/no-unsupported-browser-features": [true, {
       "severity": "warning",
-      "browsers": ["> .5% in US and last 2 version"],
       "ignore": [
         "calc",
         "css-featurequeries",

--- a/package-lock.json
+++ b/package-lock.json
@@ -876,6 +876,12 @@
         }
       }
     },
+    "caniuse-lite": {
+      "version": "1.0.30001142",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001142.tgz",
+      "integrity": "sha512-pDPpn9ankEpBFZXyCv2I4lh1v/ju+bqb78QfKf+w9XgDAFWBwSYPswXqprRdrgQWK0wQnpIbfwRjNHO1HWqvoQ==",
+      "dev": true
+    },
     "ccount": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.5.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -876,12 +876,6 @@
         }
       }
     },
-    "caniuse-lite": {
-      "version": "1.0.30001099",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001099.tgz",
-      "integrity": "sha512-sdS9A+sQTk7wKoeuZBN/YMAHVztUfVnjDi4/UV3sDE8xoh7YR12hKW+pIdB3oqKGwr9XaFL2ovfzt9w8eUI5CA==",
-      "dev": true
-    },
     "ccount": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/ccount/-/ccount-1.0.5.tgz",
@@ -4672,9 +4666,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.1.tgz",
-      "integrity": "sha512-9bY+5ZWCfqj3ghYBLxApy2zf6m+NJo5GzmLTpr9FsApsfjriNnS2dahWReHMi7qNPhhHl9SYHJs2cHZLgexNIw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.2.tgz",
+      "integrity": "sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==",
       "dev": true
     },
     "pretty-quick": {
@@ -5860,9 +5854,9 @@
       "dev": true
     },
     "stylelint": {
-      "version": "13.7.1",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.7.1.tgz",
-      "integrity": "sha512-qzqazcyRxrSRdmFuO0/SZOJ+LyCxYy0pwcvaOBBnl8/2VfHSMrtNIE+AnyJoyq6uKb+mt+hlgmVrvVi6G6XHfQ==",
+      "version": "13.7.2",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.7.2.tgz",
+      "integrity": "sha512-mmieorkfmO+ZA6CNDu1ic9qpt4tFvH2QUB7vqXgrMVHe5ENU69q7YDq0YUg/UHLuCsZOWhUAvcMcLzLDIERzSg==",
       "dev": true,
       "requires": {
         "@stylelint/postcss-css-in-js": "^0.37.2",
@@ -5947,12 +5941,6 @@
             "postcss": "^7.0.32",
             "postcss-value-parser": "^4.1.0"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001131",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001131.tgz",
-          "integrity": "sha512-4QYi6Mal4MMfQMSqGIRPGbKIbZygeN83QsWq1ixpUwvtfgAZot5BrCKzGygvZaV+CnELdTwD0S4cqUNozq7/Cw==",
-          "dev": true
         },
         "import-lazy": {
           "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,10 @@
     "test-content": "extra-eyes _posts/ --dict=library.dic",
     "test": "npm run test-content && tape tests/*.test.js | tap-spec",
     "pretty-quick": "pretty-quick",
-    "stylelint": "stylelint  \"_sass/**/*.scss\" --fix",
-    "lint": "npm run pretty-quick && npm run stylelint"
+    "stylelint": "npm run browser-list && stylelint  \"_sass/**/*.scss\" --fix",
+    "lint": "npm run pretty-quick && npm run stylelint",
+    "browser-list": "echo Browser support list: && npx browserslist",
+    "browser-update": "npx browserslist@latest --update-db"
   },
   "repository": {
     "type": "git",
@@ -24,9 +26,9 @@
     "extra-eyes": "^1.3.0",
     "husky": "^4.3.0",
     "js-yaml": "^3.14.0",
-    "prettier": "^2.1.1",
+    "prettier": "^2.1.2",
     "pretty-quick": "^3.0.2",
-    "stylelint": "^13.7.1",
+    "stylelint": "^13.7.2",
     "stylelint-a11y": "^1.2.3",
     "stylelint-config-rational-order": "^0.1.2",
     "stylelint-config-standard": "^20.0.0",


### PR DESCRIPTION
- Removes duplicate browserslist config from .stylelintrc
- Changes `.stylelintrc` to use `unit-allowed-list:`
- Names .browserslistrc properly — missed a "s"
- Updates node dependences
- Adds npm run browser-list to display list of supported browsers
- Adds npm run browser-update to update the Can I Use DB for latest browser info
