### PR TITLE
double-great/great-great-jekyll-theme@v1.0.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ author:
 
 github: double-great/listen
 
-remote_theme: double-great/great-great-jekyll-theme@main
+remote_theme: double-great/great-great-jekyll-theme@v1.0.0
 
 permalink: /:title/
 


### PR DESCRIPTION
Switching from pulling the theme from `main` branch to a versioned tag.

