### PR TITLE
Perf game

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,7 +210,7 @@ GEM
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
-    minitest (5.16.3)
+    minitest (5.17.0)
     nokogiri (1.13.10-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.10-x86_64-linux)

--- a/_config.yml
+++ b/_config.yml
@@ -15,9 +15,6 @@ permalink: /:title/
 header_pages:
   - related-resources.md
 
-custom_head: |
-  <script src="https://unpkg.com/plyr"></script>
-
 plugins:
   - jekyll-feed
   - jekyll-sitemap
@@ -36,6 +33,9 @@ defaults:
     values:
       layout: "test"
       permalink: /:basename/test/
+
+sass:
+  style: compressed
 
 collections:
   cases:

--- a/_includes/audio.html
+++ b/_includes/audio.html
@@ -3,6 +3,7 @@
     controls
     src="{{site.baseurl}}/audio/{{include.file}}"
     class="js-player"
+    preload="none"
   >
     Your browser does not support the
     <code>audio</code> element.

--- a/_includes/table.html
+++ b/_includes/table.html
@@ -47,6 +47,7 @@
 </div>
 <p><a class="button" href="test">View test case page</a></p>
 
+<script src="https://unpkg.com/plyr"></script>
 <script>
   var players = Plyr.setup(".js-player", {
     controls: ["play", "mute"],


### PR DESCRIPTION
I noticed that pages with a lot of audio embeds are receiving very low Lighthouse performance scores. This PR:
1. adds `preload="none"` to all the `<audio>` elements
2. moves the [Plyr](https://plyr.io/) JS call to the place where it is always used — the `table.html` include
3. adds compression to SCSS output 
4. commits the result of `bundle update` 