### PR TITLE
Hotfixes

### DIFF
--- a/_sass/great-great.scss
+++ b/_sass/great-great.scss
@@ -1,0 +1,11 @@
+@import "variables";
+@import "themes";
+@import "helpers";
+@import "webfonts";
+@import "base";
+@import "junkdrawer";
+@import "navigation";
+@import "home";
+@import "404";
+@import "table";
+@import "plyr";

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "pretty-quick": "pretty-quick",
     "stylelint": "npm run browser-list && stylelint  \"_sass/**/*.scss\" --fix",
     "lint": "npm run pretty-quick && npm run stylelint",
+    "local": "npm run stylelint && bundle exec jekyll serve --watch",
     "browser-list": "echo Browser support list: && npx browserslist",
     "browser-update": "npx browserslist@latest --update-db"
   },


### PR DESCRIPTION
Fix CSS regression from https://github.com/double-great/theme/pull/123. When the CSS was inlined, it stopped accounting for `_table.scss` and `_plyr.scss`. This adds a localized `great-great.scss` to pull this files in before inlining. 