### PR TITLE
Ignore Ruby vendor and bundle directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 _site/
 .sass-cache
 node_modules/
+vendor/
+.bundle/


### PR DESCRIPTION
The dependency updater tried to commit +5000 files — this PR adds `vendor` and `.bundle` to the ignore list to prevent that.